### PR TITLE
Unit function refactor

### DIFF
--- a/src/integrators.py
+++ b/src/integrators.py
@@ -123,38 +123,38 @@ class MonteCarlo(Integrator):
             fx.mul_(log_detJ.exp_().unsqueeze_(1))
             integ_values += fx / epoch
 
+        return self.collect_statistic(integ_values, f_dim, multigpu)
+
+    def collect_statistic(self, values, f_dim, multigpu=False):
         results = np.array([RAvg() for _ in range(f_dim)])
         if multigpu:
-            self.multi_gpu_statistic(integ_values, f_dim, results)
+            _mean = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
+            _total_mean = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
+            _var = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
+            for i in range(f_dim):
+                _total_mean[i] = values[:, i].mean()
+                _mean[i] = _total_mean[i]
+                _var = values[:, i].var() / self.nbatch
+
+            dist.all_reduce(_total_mean, op=dist.ReduceOp.SUM)
+            _total_mean /= dist.get_world_size()
+            _var_between_batch = torch.square(_mean - _total_mean)
+            dist.all_reduce(_var_between_batch, op=dist.ReduceOp.SUM)
+            _var_between_batch /= dist.get_world_size()
+            dist.all_reduce(_var, op=dist.ReduceOp.SUM)
+            _var /= dist.get_world_size()
+            _var = _var + _var_between_batch
+            for i in range(f_dim):
+                results[i].update(_total_mean[i].item(), _var[i].item(), self.neval)
         else:
             for i in range(f_dim):
-                _mean = integ_values[:, i].mean().item()
-                _var = integ_values[:, i].var().item() / self.nbatch
+                _mean = values[:, i].mean().item()
+                _var = values[:, i].var().item() / self.nbatch
                 results[i].update(_mean, _var, self.neval)
         if f_dim == 1:
             return results[0]
         else:
             return results
-
-    def multi_gpu_statistic(self, values, f_dim, results):
-        _mean = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
-        _total_mean = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
-        _var = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
-        for i in range(f_dim):
-            _total_mean[i] = values[:, i].mean()
-            _mean[i] = _total_mean[i]
-            _var = values[:, i].var() / self.nbatch
-
-        dist.all_reduce(_total_mean, op=dist.ReduceOp.SUM)
-        _total_mean /= dist.get_world_size()
-        _var_between_batch = torch.square(_mean - _total_mean)
-        dist.all_reduce(_var_between_batch, op=dist.ReduceOp.SUM)
-        _var_between_batch /= dist.get_world_size()
-        dist.all_reduce(_var, op=dist.ReduceOp.SUM)
-        _var /= dist.get_world_size()
-        _var = _var + _var_between_batch
-        for i in range(f_dim):
-            results[i].update(_total_mean[i].item(), _var[i].item(), self.neval)
 
 
 def random_walk(dim, bounds, device, dtype, u, **kwargs):
@@ -188,12 +188,43 @@ class MCMC(MonteCarlo):
         nburnin: int = 500,
         device="cpu",
         dtype=torch.float64,
+        rtol=1e-16,
     ):
         super().__init__(maps, bounds, q0, neval, nbatch, device, dtype)
-        self.nburnin = nburnin
         if maps is None:
             self.maps = Linear([(0, 1)] * self.dim, device=device)
+        self.nburnin = nburnin
+        self.u, self.jac = self.q0.sample(self.nbatch)
+        self.x, detJ = self.maps.forward(self.u)
+        self.jac += detJ
+        self.jac.exp_()
+        self.weight = torch.zeros_like(self.jac)
+        self.rtol = rtol
         self._rangebounds = self.bounds[:, 1] - self.bounds[:, 0]
+
+    def metropolis_hastings(self, proposal_dist, f, fx_weight, fx, mix_rate, **kwargs):
+        proposed_u = proposal_dist(
+            self.dim, self.bounds, self.device, self.dtype, self.u, **kwargs
+        )
+        proposed_x, new_jac = self.maps.forward(proposed_u)
+        new_jac.exp_()
+
+        fx_weight[:] = f(proposed_x, fx)
+        fx_weight.abs_()
+        new_weight = mix_rate / new_jac + (1 - mix_rate) * fx_weight
+        new_weight.masked_fill_(new_weight < self.rtol, self.rtol)
+
+        acceptance_probs = new_weight / self.weight * new_jac / self.jac
+
+        accept = (
+            torch.rand(self.nbatch, dtype=torch.float64, device=self.device)
+            <= acceptance_probs
+        )
+
+        self.u = torch.where(accept.unsqueeze(1), proposed_u, self.u)
+        self.x = torch.where(accept.unsqueeze(1), proposed_x, self.x)
+        self.weight = torch.where(accept, new_weight, self.weight)
+        self.jac = torch.where(accept, new_jac, self.jac)
 
     def __call__(
         self,
@@ -205,50 +236,20 @@ class MCMC(MonteCarlo):
         multigpu=False,
         **kwargs,
     ):
-        epsilon = 1e-16  # Small value to ensure numerical stability
         epoch = self.neval // self.nbatch
-        current_y, current_jac = self.q0.sample(self.nbatch)
-        current_x, detJ = self.maps.forward(current_y)
-        current_jac += detJ
-        current_jac.exp_()
         fx = torch.empty((self.nbatch, f_dim), dtype=self.dtype, device=self.device)
         fx_weight = torch.empty(self.nbatch, dtype=self.dtype, device=self.device)
-        fx_weight[:] = f(current_x, fx)
+        fx_weight[:] = f(self.x, fx)
         fx_weight.abs_()
 
-        current_weight = mix_rate / current_jac + (1 - mix_rate) * fx_weight
-        current_weight.masked_fill_(current_weight < epsilon, epsilon)
+        self.weight = mix_rate / self.jac + (1 - mix_rate) * fx_weight
+        self.weight.masked_fill_(self.weight < self.rtol, self.rtol)
 
         n_meas = epoch // meas_freq
 
-        def one_step(current_y, current_x, current_weight, current_jac):
-            proposed_y = proposal_dist(
-                self.dim, self.bounds, self.device, self.dtype, current_y, **kwargs
-            )
-            proposed_x, new_jac = self.maps.forward(proposed_y)
-            new_jac.exp_()
-
-            fx_weight[:] = f(proposed_x, fx)
-            fx_weight.abs_()
-            new_weight = mix_rate / new_jac + (1 - mix_rate) * fx_weight
-            new_weight.masked_fill_(new_weight < epsilon, epsilon)
-
-            acceptance_probs = new_weight / current_weight * new_jac / current_jac
-
-            accept = (
-                torch.rand(self.nbatch, dtype=torch.float64, device=self.device)
-                <= acceptance_probs
-            )
-
-            current_y = torch.where(accept.unsqueeze(1), proposed_y, current_y)
-            current_x = torch.where(accept.unsqueeze(1), proposed_x, current_x)
-            current_weight = torch.where(accept, new_weight, current_weight)
-            current_jac = torch.where(accept, new_jac, current_jac)
-            return current_y, current_x, current_weight, current_jac
-
         for _ in range(self.nburnin):
-            current_y, current_x, current_weight, current_jac = one_step(
-                current_y, current_x, current_weight, current_jac
+            self.metropolis_hastings(
+                proposal_dist, f, fx_weight, fx, mix_rate, **kwargs
             )
 
         values = torch.zeros((self.nbatch, f_dim), dtype=self.dtype, device=self.device)
@@ -256,19 +257,52 @@ class MCMC(MonteCarlo):
 
         for _ in range(n_meas):
             for _ in range(meas_freq):
-                current_y, current_x, current_weight, current_jac = one_step(
-                    current_y, current_x, current_weight, current_jac
+                self.metropolis_hastings(
+                    proposal_dist, f, fx_weight, fx, mix_rate, **kwargs
                 )
-            f(current_x, fx)
+            f(self.x, fx)
 
-            fx.div_(current_weight.unsqueeze(1))
+            fx.div_(self.weight.unsqueeze(1))
             values += fx / n_meas
-            refvalues += 1 / (current_jac * current_weight) / n_meas
+            refvalues += 1 / (self.jac * self.weight) / n_meas
+        return self.collect_statistic(values, refvalues, f_dim, multigpu)
 
+    def collect_statistic(self, values, refvalues, f_dim, multigpu=False):
         results = np.array([RAvg() for _ in range(f_dim)])
         results_ref = RAvg()
         if multigpu:
-            self.multi_gpu_statistic(values, refvalues, results, results_ref, f_dim)
+            _mean = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
+            _total_mean = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
+            _var = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
+            for i in range(f_dim):
+                _total_mean[i] = values[:, i].mean()
+                _mean[i] = _total_mean[i]
+                _var = values[:, i].var() / self.nbatch
+
+            dist.all_reduce(_total_mean, op=dist.ReduceOp.SUM)
+            _total_mean /= dist.get_world_size()
+            _var_between_batch = torch.square(_mean - _total_mean)
+            dist.all_reduce(_var_between_batch, op=dist.ReduceOp.SUM)
+            _var_between_batch /= dist.get_world_size()
+            dist.all_reduce(_var, op=dist.ReduceOp.SUM)
+            _var /= dist.get_world_size()
+            _var = _var + _var_between_batch
+            for i in range(f_dim):
+                results[i].update(_total_mean[i].item(), _var[i].item(), self.neval)
+
+            # collect multigpu statistics for refvalues
+            _mean_ref = refvalues.mean()
+            _total_mean_ref = _mean_ref.clone().detach()
+            _var_ref = refvalues.var() / self.nbatch
+            dist.all_reduce(_total_mean_ref, op=dist.ReduceOp.SUM)
+            _total_mean_ref /= dist.get_world_size()
+            _var_ref_between_batch = torch.square(_mean_ref - _total_mean_ref)
+            dist.all_reduce(_var_ref_between_batch, op=dist.ReduceOp.SUM)
+            _var_ref_between_batch /= dist.get_world_size()
+            dist.all_reduce(_var_ref, op=dist.ReduceOp.SUM)
+            _var_ref /= dist.get_world_size()
+            _var_ref = _var_ref + _var_ref_between_batch
+            results_ref.update(_total_mean_ref.item(), _var_ref.item(), self.neval)
         else:
             mean_ref = refvalues.mean().item()
             var_ref = refvalues.var().item() / self.nbatch
@@ -284,39 +318,3 @@ class MCMC(MonteCarlo):
             return result
         else:
             return results / results_ref * self._rangebounds.prod().item()
-
-    def multi_gpu_statistic(self, values, refvalues, results, results_ref, f_dim):
-        # collect multigpu statistics for values
-        _mean = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
-        _total_mean = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
-        _var = torch.zeros(f_dim, device=self.device, dtype=self.dtype)
-        for i in range(f_dim):
-            _total_mean[i] = values[:, i].mean()
-            _mean[i] = _total_mean[i]
-            _var = values[:, i].var() / self.nbatch
-
-        dist.all_reduce(_total_mean, op=dist.ReduceOp.SUM)
-        _total_mean /= dist.get_world_size()
-        _var_between_batch = torch.square(_mean - _total_mean)
-        dist.all_reduce(_var_between_batch, op=dist.ReduceOp.SUM)
-        _var_between_batch /= dist.get_world_size()
-        dist.all_reduce(_var, op=dist.ReduceOp.SUM)
-        _var /= dist.get_world_size()
-        _var = _var + _var_between_batch
-        for i in range(f_dim):
-            results[i].update(_total_mean[i].item(), _var[i].item(), self.neval)
-
-        # collect multigpu statistics for refvalues
-        _mean_ref = refvalues.mean()
-        _total_mean_ref = _mean_ref.clone().detach()
-        _var_ref = refvalues.var() / self.nbatch
-        dist.all_reduce(_total_mean_ref, op=dist.ReduceOp.SUM)
-        _total_mean_ref /= dist.get_world_size()
-        _var_ref_between_batch = torch.square(_mean_ref - _total_mean_ref)
-        dist.all_reduce(_var_ref_between_batch, op=dist.ReduceOp.SUM)
-        _var_ref_between_batch /= dist.get_world_size()
-        dist.all_reduce(_var_ref, op=dist.ReduceOp.SUM)
-        _var_ref /= dist.get_world_size()
-        _var_ref = _var_ref + _var_ref_between_batch
-        results_ref.update(_total_mean_ref.item(), _var_ref.item(), self.neval)
-        # return results, results_ref

--- a/src/mc_multigpu_test.py
+++ b/src/mc_multigpu_test.py
@@ -1,6 +1,6 @@
 import torch
 from integrators import MonteCarlo, MCMC, setup
-from maps import Vegas, Linear
+from maps import Vegas
 from utils import set_seed, get_device
 
 # set_seed(42)

--- a/src/mc_test.py
+++ b/src/mc_test.py
@@ -1,7 +1,7 @@
 # Integration tests for MonteCarlo and MCMC integrators class.
 import torch
 from integrators import MonteCarlo, MCMC
-from maps import Vegas, Linear
+from maps import Vegas
 from utils import set_seed, get_device
 
 set_seed(42)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,10 +1,7 @@
 import torch
 import numpy as np
 import gvar
-import sys
-
-MINVAL = 10 ** (sys.float_info.min_10_exp + 50)
-MAXVAL = 10 ** (sys.float_info.max_10_exp - 50)
+from base import MAXVAL, MINVAL
 
 
 class RAvg(gvar.GVar):

--- a/src/vegas_test.py
+++ b/src/vegas_test.py
@@ -1,7 +1,7 @@
 # Integration tests for VEGAS + MonteCarlo/MCMC integral methods.
 import torch
 from integrators import MonteCarlo, MCMC
-from maps import Vegas, Linear
+from maps import Vegas
 from utils import set_seed, get_device
 
 set_seed(42)
@@ -35,15 +35,16 @@ def func(x, f):
 
 
 ninc = 1000
+nsamples_train = 40000
 n_eval = 50000
 n_batch = 10000
 n_therm = 10
 
 print("\nCalculate the integral log(x)/x^0.5 in the bounds [0, 1]")
 
-print("train VEGAS map")
+print("train VEGAS map by importance sampling data")
 vegas_map = Vegas([(0, 1)], device=device, ninc=ninc)
-vegas_map.train(20000, func, epoch=10, alpha=0.5)
+vegas_map.train(nsamples_train, func, epoch=10, alpha=1.0)
 
 vegas_integrator = MonteCarlo(
     maps=vegas_map,
@@ -63,7 +64,22 @@ vegasmcmc_integrator = MCMC(
 )
 res = vegasmcmc_integrator(func, mix_rate=0.5)
 print("VEGAS-MCMC Integral results: ", res)
-print(type(res))
+
+vegas_map.make_uniform()
+print("\ntrain VEGAS map by MCMC sampling data")
+vegas_map.train_mcmc(nsamples_train, func, epoch=10, alpha=1.0)
+res = vegas_integrator(func)
+print("VEGAS Integral results: ", res)
+
+res = vegasmcmc_integrator(func, mix_rate=0.5)
+print("VEGAS-MCMC Integral results: ", res)
+
+vegas_map.make_uniform()
+res = vegas_integrator(func)
+print("\nNaive MC Integral results: ", res)
+res = vegasmcmc_integrator(func, mix_rate=0.5)
+print("MCMC Integral results: ", res)
+
 
 # Start Monte Carlo integration, including plain-MC, MCMC, vegas, and vegas-MCMC
 print("\nCalculate the integral [h(X), x1 * h(X),  x1^2 * h(X)] in the bounds [0, 1]^4")
@@ -72,8 +88,7 @@ print("h(X) = exp(-200 * (x1^2 + x2^2 + x3^2 + x4^2))")
 bounds = [(0, 1)] * 4
 vegas_map = Vegas(bounds, device=device, ninc=ninc)
 print("train VEGAS map for h(X)...")
-vegas_map.train(20000, sharp_peak, epoch=10, alpha=0.5)
-# print(vegas_map.extract_grid())
+vegas_map.train(nsamples_train, sharp_peak, epoch=10, alpha=1.0)
 
 print("VEGAS Integral results:")
 vegas_integrator = MonteCarlo(
@@ -93,11 +108,11 @@ print(
     "  I[1]/I[0] =",
     res[1] / res[0],
 )
-print(type(res))
-print(type(res[0]))
-print(res[0].sum_neval)
-print(res[0].itn_results)
-print(res[0].nitn)
+# print(type(res))
+# print(type(res[0]))
+# print(res[0].sum_neval)
+# print(res[0].itn_results)
+# print(res[0].nitn)
 
 
 print("VEGAS-MCMC Integral results:")
@@ -109,6 +124,34 @@ vegasmcmc_integrator = MCMC(
     device=device,
 )
 res = vegasmcmc_integrator(sharp_integrands, f_dim=3, mix_rate=0.5)
+print(
+    "  I[0] =",
+    res[0],
+    "  I[1] =",
+    res[1],
+    "  I[2] =",
+    res[2],
+    "  I[1]/I[0] =",
+    res[1] / res[0],
+)
+
+vegas_map.make_uniform()
+print("\ntrain VEGAS map by MCMC sampling data...")
+vegas_map.train_mcmc(nsamples_train, sharp_peak, epoch=10, alpha=1.0)
+res = vegas_integrator(sharp_integrands, f_dim=3)
+print("VEGAS Integral results: ")
+print(
+    "  I[0] =",
+    res[0],
+    "  I[1] =",
+    res[1],
+    "  I[2] =",
+    res[2],
+    "  I[1]/I[0] =",
+    res[1] / res[0],
+)
+res = vegasmcmc_integrator(sharp_integrands, f_dim=3, mix_rate=0.5)
+print("VEGAS-MCMC Integral results: ")
 print(
     "  I[0] =",
     res[0],


### PR DESCRIPTION
1. Factor out collect_statistic() function.
2. Factor out metropolis_hastings() in MCMC.
These unit functions makes it easy for user to combine freely and create their work flow. The __call__() function for Integrators is still kept as a default work flow.